### PR TITLE
Update build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
+[![Java CI](https://github.com/AY2526S1-CS2103T-F14B-1/tp/actions/workflows/gradle.yml/badge.svg)](https://github.com/AY2526S1-CS2103T-F14B-1/tp/actions/workflows/gradle.yml)
 
 ![Ui](docs/images/Ui.png)
 


### PR DESCRIPTION
Update the link of the GitHub Actions build status badge inside README.md

Closes #24 