### PR TITLE
Change Note command prefix

### DIFF
--- a/src/main/java/seedu/address/logic/commands/NoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteCommand.java
@@ -23,9 +23,9 @@ public class NoteCommand extends Command {
             + "by the index number used in the last person listing. "
             + "Existing note will be overwritten by the input.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "no/ [NOTE]\n"
+            + "desc/ [NOTE]\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + "no/ Allergic to peanut.";
+            + "desc/ Allergic to peanut.";
 
     public static final String MESSAGE_ARGUMENTS = "Index: %1$d, Note: %2$s";
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,6 +11,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-    public static final Prefix PREFIX_NOTE = new Prefix("no/");
+    public static final Prefix PREFIX_NOTE = new Prefix("desc/");
 
 }


### PR DESCRIPTION
Change the prefix of Note command from `no/` to `desc/` to avoid ambiguity

closes #75 