### PR TITLE
Implement LittleLogBook mockup color scheme

### DIFF
--- a/src/main/resources/view/LittleLogBookTheme.css
+++ b/src/main/resources/view/LittleLogBookTheme.css
@@ -1,0 +1,375 @@
+.background {
+    -fx-background-color: linear-gradient(to bottom, #B1DFF3, #FFFFFF);
+    background-color: #B1DFF3;
+}
+
+.root {
+    -fx-background-color: linear-gradient(to bottom, #B1DFF3, #FFFFFF);
+}
+
+.label {
+    -fx-font-size: 11pt;
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-text-fill: #555555;
+    -fx-opacity: 0.9;
+}
+
+.label-bright {
+    -fx-font-size: 11pt;
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-text-fill: #005074;
+    -fx-opacity: 1;
+}
+
+.label-header {
+    -fx-font-size: 32pt;
+    -fx-font-family: "Segoe UI Light";
+    -fx-text-fill: #005074;
+    -fx-opacity: 1;
+}
+
+.text-field {
+    -fx-font-size: 12pt;
+    -fx-font-family: "Segoe UI Semibold";
+}
+
+.tab-pane {
+    -fx-padding: 0 0 0 1;
+}
+
+.tab-pane .tab-header-area {
+    -fx-padding: 0 0 0 0;
+    -fx-min-height: 0;
+    -fx-max-height: 0;
+    -fx-background-color: transparent;
+}
+
+.table-view {
+    -fx-base: #1d1d1d;
+    -fx-control-inner-background: transparent;
+    -fx-background-color: transparent;
+    -fx-table-cell-border-color: transparent;
+    -fx-table-header-border-color: transparent;
+    -fx-padding: 5;
+}
+
+.table-view .column-header-background {
+    -fx-background-color: #9CC3D5;
+}
+
+.table-view .column-header, .table-view .filler {
+    -fx-size: 35;
+    -fx-border-width: 0 0 1 0;
+    -fx-background-color: #9CC3D5;
+    -fx-border-color:
+        transparent
+        transparent
+        derive(-fx-base, 80%)
+        transparent;
+    -fx-border-insets: 0 10 1 0;
+}
+
+.table-view .column-header .label {
+    -fx-font-size: 20pt;
+    -fx-font-family: "Segoe UI Light";
+    -fx-text-fill: #005074;
+    -fx-alignment: center-left;
+    -fx-opacity: 1;
+}
+
+.table-view:focused .table-row-cell:filled:focused:selected {
+    -fx-background-color: -fx-focus-color;
+}
+
+.split-pane:horizontal .split-pane-divider {
+    -fx-background-color: #9CC3D5;
+    -fx-border-color: transparent;
+}
+
+.split-pane {
+    -fx-border-radius: 1;
+    -fx-border-width: 1;
+    -fx-background-color: transparent;
+}
+
+.list-view {
+    -fx-background-insets: 0;
+    -fx-padding: 0;
+    -fx-background-color: transparent;
+}
+
+.list-cell {
+    -fx-label-padding: 0 0 0 0;
+    -fx-graphic-text-gap : 0;
+    -fx-padding: 0 0 0 0;
+    -fx-background-color: transparent;
+}
+
+.list-cell:filled:even {
+    -fx-background-color: #9CC3D5;
+    -fx-border-color: #2681AC transparent #2681AC transparent;
+}
+
+.list-cell:filled:odd {
+    -fx-background-color: #9CC3D5;
+    -fx-border-color: #2681AC transparent #2681AC transparent;
+}
+
+.list-cell:filled:selected {
+    -fx-background-color: #5f95ad;
+}
+
+.list-cell:filled:selected #cardPane {
+    -fx-border-color: #5f95ad;
+    -fx-border-width: 1;
+}
+
+.list-cell:filled:selected .label {
+    -fx-text-fill: white;
+}
+
+.list-cell .label {
+    -fx-text-fill: #005074;
+}
+
+.cell_big_label {
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-size: 16px;
+    -fx-text-fill: #010504;
+}
+
+.cell_small_label {
+    -fx-font-family: "Segoe UI";
+    -fx-font-size: 13px;
+    -fx-text-fill: #010504;
+}
+
+.stack-pane {
+     -fx-background-color: transparent;
+}
+
+.pane-with-border {
+     -fx-background-color: transparent;
+     -fx-border-color: transparent;
+     -fx-border-top-width: 1px;
+}
+
+.status-bar {
+    -fx-background-color: #9CC3D5;
+}
+
+.result-display {
+    -fx-background-color: transparent;
+    -fx-font-family: "Segoe UI Light";
+    -fx-font-size: 13pt;
+    -fx-text-fill: #005074;
+}
+
+.result-display .label {
+    -fx-text-fill: #005074 !important;
+}
+
+.status-bar .label {
+    -fx-font-family: "Segoe UI Light";
+    -fx-text-fill: #005074;
+    -fx-padding: 4px;
+    -fx-pref-height: 30px;
+}
+
+.status-bar-with-border {
+    -fx-background-color: #9CC3D5;
+    -fx-border-color: transparent;
+    -fx-border-width: 1px;
+}
+
+.status-bar-with-border .label {
+    -fx-text-fill: #005074;
+}
+
+.grid-pane {
+    -fx-background-color: transparent;
+    -fx-border-color: transparent;
+    -fx-border-width: 1px;
+}
+
+.grid-pane .stack-pane {
+    -fx-background-color: transparent;
+}
+
+.context-menu {
+    -fx-background-color: white;
+}
+
+.context-menu .label {
+    -fx-text-fill: #005074;
+}
+
+.menu-bar {
+    -fx-background-color: #9CC3D5;
+}
+
+.menu-bar .label {
+    -fx-font-size: 14pt;
+    -fx-font-family: "Segoe UI Light";
+    -fx-text-fill: #005074;
+    -fx-opacity: 0.9;
+}
+
+.menu .left-container {
+    -fx-background-color: transparent;
+}
+
+/*
+ * Metro style Push Button
+ * Author: Pedro Duque Vieira
+ * http://pixelduke.wordpress.com/2012/10/23/jmetro-windows-8-controls-on-java/
+ */
+.button {
+    -fx-padding: 5 22 5 22;
+    -fx-border-color: #e2e2e2;
+    -fx-border-width: 2;
+    -fx-background-radius: 0;
+    -fx-background-color: #9CC3D5;
+    -fx-font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+    -fx-font-size: 11pt;
+    -fx-text-fill: #005074;
+    -fx-background-insets: 0 0 0 0, 0, 1, 2;
+}
+
+.button:hover {
+    -fx-background-color: #3a3a3a;
+}
+
+.button:pressed, .button:default:hover:pressed {
+  -fx-background-color: white;
+  -fx-text-fill: white;
+}
+
+.button:focused {
+    -fx-border-color: white, white;
+    -fx-border-width: 1, 1;
+    -fx-border-style: solid, segments(1, 1);
+    -fx-border-radius: 0, 0;
+    -fx-border-insets: 1 1 1 1, 0;
+}
+
+.button:disabled, .button:default:disabled {
+    -fx-opacity: 0.4;
+    -fx-background-color: #9CC3D5;
+    -fx-text-fill: #005074;
+}
+
+.button:default {
+    -fx-background-color: -fx-focus-color;
+    -fx-text-fill: #ffffff;
+}
+
+.button:default:hover {
+    -fx-background-color: derive(-fx-focus-color, 30%);
+}
+
+.dialog-pane {
+    -fx-background-color: #9CC3D5;
+}
+
+.dialog-pane > *.button-bar > *.container {
+    -fx-background-color: #9CC3D5;
+}
+
+.dialog-pane > *.label.content {
+    -fx-font-size: 14px;
+    -fx-font-weight: bold;
+    -fx-text-fill: white;
+}
+
+.dialog-pane:header *.header-panel {
+    -fx-background-color: #9CC3D5;
+}
+
+.dialog-pane:header *.header-panel *.label {
+    -fx-font-size: 18px;
+    -fx-font-style: italic;
+    -fx-text-fill: #005074;
+}
+
+.scroll-bar {
+    -fx-background-color: #81A8BA;
+}
+
+.scroll-bar .thumb {
+    -fx-background-color: #4D6570;
+    -fx-background-insets: 3;
+}
+
+.scroll-bar .increment-button, .scroll-bar .decrement-button {
+    -fx-background-color: #4D6570;
+    -fx-padding: 0 0 0 0;
+}
+
+.scroll-bar .increment-arrow, .scroll-bar .decrement-arrow {
+    -fx-shape: " ";
+}
+
+.scroll-bar:vertical .increment-arrow, .scroll-bar:vertical .decrement-arrow {
+    -fx-padding: 1 8 1 8;
+}
+
+.scroll-bar:horizontal .increment-arrow, .scroll-bar:horizontal .decrement-arrow {
+    -fx-padding: 8 1 8 1;
+}
+
+#cardPane {
+    -fx-background-color: transparent;
+    -fx-border-width: 0;
+}
+
+#commandTypeLabel {
+    -fx-font-size: 11px;
+    -fx-text-fill: #F70D1A;
+}
+
+#commandTextField {
+    -fx-background-color: #ffffff;
+    -fx-background-insets: 0;
+    -fx-background-radius: 100;
+    -fx-border-color: #ffffff;
+    -fx-border-insets: 0;
+    -fx-border-width: 1;
+    -fx-border-radius: 100;
+    -fx-font-family: "Segoe UI Light";
+    -fx-font-size: 13pt;
+    -fx-text-fill: #005074;
+    -fx-padding: 5 14 5 14;
+}
+
+#filterField {
+    -fx-background-color: white;
+    -fx-background-radius: 100;
+    -fx-border-color: #2681AC;
+    -fx-border-width: 2;
+    -fx-border-radius: 100;
+}
+
+#filterField, #personListPanel, #personWebpage {
+     -fx-effect: dropshadow(gaussian, rgba(0,80,116,0.1), 8, 0, 0, 2);
+}
+
+#resultDisplay .content {
+    -fx-background-color: #9CC3D5;
+    -fx-background-radius: 0;
+}
+
+#tags {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#tags .label {
+    -fx-text-fill: white;
+    -fx-background-color: #3e7b91;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+}
+

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -19,7 +19,7 @@
   <scene>
     <Scene>
       <stylesheets>
-        <URL value="@DarkTheme.css" />
+        <URL value="@LittleLogBookTheme.css" />
         <URL value="@Extensions.css" />
       </stylesheets>
 


### PR DESCRIPTION
Updated default dark theme from addressbook into the LittleLogBook mockup color scheme.
<img width="695" height="712" alt="image" src="https://github.com/user-attachments/assets/5a1d2ed8-4936-4f47-b81d-e428c1fe5ce4" />

Moving forward, let's try to make the rest of the UI softer / friendlier with more rounded elements similar to mock ups.

closes #71 